### PR TITLE
This is a test data portal add in using the term Datasets. 

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -1226,6 +1226,210 @@ content:
         type: string
         list: true
   # --------------------------------------------------------------------------
+  # Datasets (Data Catalog)
+  #
+  # Fields intentionally OMITTED from this form (pre-populated for all
+  # M-Lab datasets at render time):
+  #   dc:creator / dc:publisher  → "Measurement Lab"
+  #   dc:language                → "en"
+  #   dc:type                    → "Dataset"
+  #   dc:rights / license        → "CC0 1.0 Universal"
+  #   dc:subject                 → Internet measurement, Network performance,
+  #                                 Broadband, Open data
+  # --------------------------------------------------------------------------
+  - name: datasets
+    label: Datasets
+    type: collection
+    path: src/content/datasets
+    format: json
+    filename: '{fields.id}.json'
+    subfolders: false
+    view:
+      fields: [title, updateFrequency, status]
+      sort: [title]
+      search: [title, description, keywords]
+      primary: title
+    fields:
+      - name: id
+        label: ID
+        type: string
+        required: true
+        description: URL-safe identifier (e.g. ndt, wehe, traceroute). Becomes the page path /datasets/<id>/.
+        pattern:
+          message: "Must be a URL-safe string like 'ndt' or 'my-dataset'."
+          regex: '^[a-zA-Z0-9_-]+$'
+
+      - name: title
+        label: Dataset Name
+        type: string
+        required: true
+        description: Full human-readable name of the dataset (dc:title)
+
+      - name: status
+        label: Status
+        type: select
+        required: true
+        default: draft
+        options:
+          values:
+            - label: Draft
+              value: draft
+            - label: Published
+              value: published
+            - label: Archived
+              value: archived
+        description: Draft datasets are only visible on the preview site.
+
+      - name: description
+        label: Description
+        type: text
+        required: true
+        description: "Plain-text description of what this dataset contains and how it was collected. Used in search results and as dc:description / schema.org description. (Tip: 2–4 sentences works well.)"
+
+      - name: keywords
+        label: Keywords
+        type: string
+        list: true
+        description: "Dataset-specific search terms (e.g. 'TCP throughput', 'NDT', 'video streaming'). M-Lab base terms (Internet measurement, Network performance, Broadband, Open data) are added automatically."
+
+      - name: category
+        label: Data Category
+        type: select
+        required: false
+        options:
+          values:
+            - label: Raw — archival measurement logs (GCS)
+              value: raw
+            - label: Enriched — parsed and queryable (BigQuery)
+              value: enriched
+        description: "Raw = unprocessed archives on GCS. Enriched = parsed, annotated, queryable via BigQuery."
+
+      - name: testRef
+        label: Related Test
+        type: reference
+        required: false
+        options:
+          collection: tests
+          value: '{fields.slug}'
+          label: '{title}'
+        description: The M-Lab test that generates this dataset (links the dataset page to the test page)
+
+      - name: relatedDatasets
+        label: Related Datasets
+        type: reference
+        required: false
+        options:
+          collection: datasets
+          multiple: true
+          value: '{id}'
+          label: '{title}'
+        description: Other datasets that are closely related (e.g. protocol variants, companion datasets)
+
+      - name: temporalCoverageStart
+        label: Coverage Start Date
+        type: string
+        required: false
+        description: "ISO 8601 date when data collection began (e.g. 2009-01-01)"
+        pattern:
+          message: "Must be an ISO date like 2009-01-01"
+          regex: '^\d{4}-\d{2}-\d{2}$'
+
+      - name: temporalCoverageEnd
+        label: Coverage End Date
+        type: string
+        required: false
+        description: "ISO 8601 end date, or the word 'present' if collection is ongoing"
+
+      - name: spatialCoverage
+        label: Spatial Coverage
+        type: string
+        required: false
+        default: Global
+        description: "Geographic scope of the data (default: Global)"
+
+      - name: updateFrequency
+        label: Update Frequency
+        type: select
+        required: false
+        options:
+          values:
+            - label: Continuous (real-time)
+              value: continuous
+            - label: Daily
+              value: daily
+            - label: Weekly
+              value: weekly
+            - label: Monthly
+              value: monthly
+            - label: Irregular
+              value: irregular
+            - label: Static (no further updates)
+              value: static
+        description: How often new measurements are added to this dataset
+
+      - name: dataSize
+        label: Approximate Size
+        type: string
+        required: false
+        description: "Human-readable size hint (e.g. '~2 TB/year (raw), ~500 GB/year (parsed)')"
+
+      - name: accessPoints
+        label: Access Points
+        type: object
+        list: true
+        description: Ways to access or download this dataset (BigQuery tables, GCS buckets, download URLs, etc.)
+        fields:
+          - name: label
+            label: Label
+            type: string
+            required: true
+            description: "Short display name (e.g. 'BigQuery', 'GCS', 'Download')"
+          - name: url
+            label: URL or Path
+            type: string
+            required: true
+            description: "Full URL (https://…) or GCS path (gs://…)"
+          - name: format
+            label: Format
+            type: string
+            required: true
+            description: "Data format (e.g. BigQuery, Parquet, CSV, JSON)"
+          - name: type
+            label: Type
+            type: select
+            required: false
+            options:
+              values:
+                - label: Query (interactive)
+                  value: query
+                - label: Download
+                  value: download
+                - label: API
+                  value: api
+                - label: Visualization
+                  value: viz
+          - name: description
+            label: Description
+            type: string
+            required: false
+            description: Brief explanation of what this access point provides
+
+      - name: documentationLinks
+        label: Documentation Links
+        type: object
+        list: true
+        description: Links to data documentation, schemas, acceptable use policy, etc.
+        fields:
+          - name: label
+            label: Label
+            type: string
+            required: true
+          - name: url
+            label: URL
+            type: string
+            required: true
+
+  # --------------------------------------------------------------------------
   # Site Settings (singleton)
   # --------------------------------------------------------------------------
   - name: site-config

--- a/package-lock.json
+++ b/package-lock.json
@@ -4128,6 +4128,7 @@
     },
     "node_modules/@parcel/watcher-wasm/node_modules/napi-wasm": {
       "version": "1.1.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },

--- a/src/components/landing/DatasetsLanding.astro
+++ b/src/components/landing/DatasetsLanding.astro
@@ -1,0 +1,93 @@
+---
+/**
+ * DatasetsLanding.astro
+ *
+ * Groups published datasets by category — Enriched first, then Raw.
+ * Encourages users to start with enriched data and fall back to raw.
+ */
+import { getCollection } from 'astro:content';
+import Card from '@components/molecules/Card.astro';
+import Tag from '@components/atoms/Tag';
+import SectionLayout from '@layouts/SectionLayout.astro';
+import { isVisible } from '@utils/content';
+
+const allDatasets = await getCollection('datasets');
+const datasets = allDatasets.filter((ds) => isVisible(ds));
+
+type CategoryKey = 'enriched' | 'raw' | 'uncategorized';
+
+const categoryGroups: Record<CategoryKey, { title: string; description: string; datasets: typeof datasets }> = {
+  enriched: {
+    title: 'Enriched Datasets',
+    description: 'Start here. These datasets have been parsed, annotated, and structured for analysis — queryable via BigQuery or downloadable as pre-computed summaries. Most research questions can be answered without touching raw data.',
+    datasets: [],
+  },
+  raw: {
+    title: 'Raw Datasets',
+    description: "Unprocessed measurement logs and archives as collected directly from M-Lab's infrastructure, stored in Google Cloud Storage. Use these when enriched datasets don't cover your specific analysis need.",
+    datasets: [],
+  },
+  uncategorized: {
+    title: 'Other Datasets',
+    description: '',
+    datasets: [],
+  },
+};
+
+datasets.forEach((ds) => {
+  const key = (ds.data.category ?? 'uncategorized') as CategoryKey;
+  categoryGroups[key].datasets.push(ds);
+});
+
+// Sort within each group alphabetically
+(Object.values(categoryGroups) as (typeof categoryGroups[CategoryKey])[]).forEach((g) =>
+  g.datasets.sort((a, b) => a.data.title.localeCompare(b.data.title))
+);
+
+const orderedKeys: CategoryKey[] = ['enriched', 'raw', 'uncategorized'];
+const activeGroups = orderedKeys
+  .filter((key) => categoryGroups[key].datasets.length > 0)
+  .map((key) => ({ key, ...categoryGroups[key] }));
+
+const formatFrequency = (f: string) => f.charAt(0).toUpperCase() + f.slice(1);
+---
+
+<div class="pb-12">
+  {activeGroups.map((group) => (
+    <SectionLayout maxWidth="4xl" sectionLabel={`section > ${group.title}`}>
+      <div class="mb-8">
+        <h2 class="mb-2 text-2xl font-bold">{group.title}</h2>
+        {group.description && (
+          <p class="text-gray-600 max-w-2xl">{group.description}</p>
+        )}
+      </div>
+
+      <div class="grid gap-5">
+        {group.datasets.map((ds) => (
+          <Card variant="elevated" padding="lg" class="w-full" href={`/datasets/${ds.id}`}>
+            <div class="mb-3 flex flex-wrap gap-2">
+              {ds.data.updateFrequency && (
+                <Tag variant="primary" size="sm">
+                  {formatFrequency(ds.data.updateFrequency)}
+                </Tag>
+              )}
+              {ds.data.spatialCoverage && (
+                <Tag variant="secondary" size="sm">{ds.data.spatialCoverage}</Tag>
+              )}
+            </div>
+            <h3 class="mb-2 text-xl font-semibold leading-snug">{ds.data.title}</h3>
+            <p class="text-gray-600 mb-4 text-base">{ds.data.description}</p>
+            {ds.data.temporalCoverageStart && (
+              <p class="text-gray-400 mt-auto pt-3 border-t border-gray-100 text-sm">
+                {ds.data.temporalCoverageStart.slice(0, 4)}
+                {ds.data.temporalCoverageEnd
+                  ? ` – ${ds.data.temporalCoverageEnd === 'present' ? 'present' : ds.data.temporalCoverageEnd.slice(0, 4)}`
+                  : ''}
+              </p>
+            )}
+          </Card>
+        ))}
+      </div>
+    </SectionLayout>
+  ))}
+</div>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -420,6 +420,74 @@ const publicationsCollection = defineCollection({
   }),
 });
 
+// ---------------------------------------------------------------------------
+// Dataset access point - describes one way to access a dataset
+// (e.g. BigQuery table, GCS bucket, download URL)
+// ---------------------------------------------------------------------------
+const accessPointSchema = z.object({
+  label: z.string(),                              // e.g. "BigQuery", "GCS"
+  url: z.string(),                               // access URL or path
+  format: z.string(),                            // e.g. "BigQuery", "Parquet", "CSV"
+  type: z.enum(['query', 'download', 'api', 'viz']).optional(),
+  description: z.string().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Datasets collection
+//
+// Dublin Core fields with M-Lab constants pre-populated at render time:
+//   dc:creator / dc:publisher  → "Measurement Lab"
+//   dc:language                → "en"
+//   dc:type                    → "Dataset"
+//   dc:rights / license        → "CC0 1.0 Universal"
+//   dc:subject                 → ["Internet measurement", "Network performance",
+//                                  "Broadband", "Open data"]
+//
+// These are intentionally absent from the CMS form to keep entry simple.
+// ---------------------------------------------------------------------------
+const datasetsCollection = defineCollection({
+  type: 'data',
+  schema: z.object({
+    // Identity
+    id: z.string(),
+    title: z.string(),                          // dc:title
+    status: statusSchema,
+
+    // Description
+    description: z.string(),                   // dc:description (plain text for JSON-LD)
+
+    // Data category — used to group datasets on the catalog page
+    category: z.enum(['raw', 'enriched']).optional(),
+
+    // Provenance / relation
+    testRef: z.string().optional(),            // slug of associated M-Lab test
+    relatedDatasets: z.array(z.string()).optional(), // slugs of related datasets
+
+    // Temporal coverage
+    temporalCoverageStart: z.string().optional(), // ISO date string e.g. "2009-01-01"
+    temporalCoverageEnd: z.string().optional(),   // ISO date string or "present"
+
+    // Spatial coverage (defaults to "Global" at render time)
+    spatialCoverage: z.string().optional().default('Global'),
+
+    // Update cadence
+    updateFrequency: z
+      .enum(['continuous', 'daily', 'weekly', 'monthly', 'irregular', 'static'])
+      .optional(),
+
+    // Access points (BigQuery, GCS, download links, etc.)
+    accessPoints: z.array(accessPointSchema).optional(),
+
+    // Size hint (human-readable, e.g. "~500 GB/year")
+    dataSize: z.string().optional(),
+
+    // Additional documentation / external links
+    documentationLinks: z
+      .array(z.object({ label: z.string(), url: z.string() }))
+      .optional(),
+  }),
+});
+
 export const collections = {
   people: peopleCollection,
   pages: pagesCollection,
@@ -431,4 +499,5 @@ export const collections = {
   homepage: homepageCollection,
   publications: publicationsCollection,
   tests: testsCollection,
+  datasets: datasetsCollection,
 };

--- a/src/content/datasets/monthly-stats.json
+++ b/src/content/datasets/monthly-stats.json
@@ -1,0 +1,43 @@
+{
+  "id": "monthly-stats",
+  "title": "Monthly Stats",
+  "status": "published",
+  "category": "enriched",
+  "description": "Cached M-Lab summary query results available for download. These data are used to calculate the Internet Quality Barometer (IQB), but are generally useful as aggregate statistics of M-Lab's global measurements. Data are organized by month, direction (download/upload), and geographic granularity.",
+  "testRef": "ndt",
+  "relatedDatasets": ["ndt"],
+  "temporalCoverageStart": "2009-01-01",
+  "temporalCoverageEnd": "present",
+  "spatialCoverage": "Global",
+  "updateFrequency": "monthly",
+  "accessPoints": [
+    {
+      "label": "Stats Data Portal",
+      "url": "/data/stats/",
+      "format": "Portal",
+      "type": "viz",
+      "description": "Browse and download monthly stats files filtered by period, direction, and granularity"
+    },
+    {
+      "label": "GitHub (m-lab/iqb)",
+      "url": "https://github.com/m-lab/iqb/tree/main/data",
+      "format": "GitHub",
+      "type": "download",
+      "description": "Source code and data manifest for the IQB monthly stats pipeline"
+    }
+  ],
+  "documentationLinks": [
+    {
+      "label": "Internet Quality Barometer (IQB)",
+      "url": "/iqb/"
+    },
+    {
+      "label": "IQB Framework Report",
+      "url": "/publications/IQB_report_2025.pdf"
+    },
+    {
+      "label": "IQB Executive Summary",
+      "url": "/publications/IQB_executive_summary_2025.pdf"
+    }
+  ]
+}

--- a/src/content/datasets/ndt.json
+++ b/src/content/datasets/ndt.json
@@ -1,0 +1,58 @@
+{
+  "id": "ndt",
+  "title": "NDT (Network Diagnostic Tool) Dataset",
+  "status": "published",
+  "description": "The NDT dataset contains measurements of TCP throughput and latency collected by the Network Diagnostic Tool (NDT). NDT is a single-stream performance measurement of a connection's capacity for bulk transport. Measurements include download speed, upload speed, round-trip time (RTT), and packet loss between end-user devices and M-Lab servers worldwide.",
+  "category": "raw",
+  "testRef": "ndt",
+  "relatedDatasets": ["ndt5", "ndt7"],
+  "temporalCoverageStart": "2009-01-01",
+  "temporalCoverageEnd": "present",
+  "spatialCoverage": "Global",
+  "updateFrequency": "continuous",
+  "dataSize": "~2 TB/year (raw), ~500 GB/year (parsed)",
+  "accessPoints": [
+    {
+      "label": "BigQuery (ndt7)",
+      "url": "https://console.cloud.google.com/bigquery?project=measurement-lab&p=measurement-lab&d=ndt&t=ndt7_summary&page=table",
+      "format": "BigQuery",
+      "type": "query",
+      "description": "Parsed ndt7 summary table — recommended for most analyses"
+    },
+    {
+      "label": "BigQuery (ndt5)",
+      "url": "https://console.cloud.google.com/bigquery?project=measurement-lab&p=measurement-lab&d=ndt&t=ndt5_summary&page=table",
+      "format": "BigQuery",
+      "type": "query",
+      "description": "Parsed ndt5 summary table — historical data pre-2020"
+    },
+    {
+      "label": "Google Cloud Storage (raw)",
+      "url": "gs://archive.measurementlab.net/ndt/",
+      "format": "JSON / raw TCP trace",
+      "type": "download",
+      "description": "Raw measurement archives in compressed JSON and pcap format"
+    },
+    {
+      "label": "Viz — Throughput Explorer",
+      "url": "https://viz.measurementlab.net/",
+      "format": "Interactive",
+      "type": "viz",
+      "description": "Interactive visualization of NDT download and upload speeds by geography and ISP"
+    }
+  ],
+  "documentationLinks": [
+    {
+      "label": "NDT Data Documentation",
+      "url": "https://www.measurementlab.net/tests/ndt/"
+    },
+    {
+      "label": "BigQuery Schema Reference",
+      "url": "https://www.measurementlab.net/data/docs/bq/schema/"
+    },
+    {
+      "label": "Acceptable Use Policy",
+      "url": "https://www.measurementlab.net/aup/"
+    }
+  ]
+}

--- a/src/content/datasets/test.json
+++ b/src/content/datasets/test.json
@@ -1,7 +1,7 @@
 {
   "id": "test",
   "title": "Testing for Melissa",
-  "status": "published",
+  "status": "draft",
   "description": "This is to show Melissa how to make a dataset. ",
   "category": "enriched",
   "temporalCoverageStart": "2009-01-01",

--- a/src/content/datasets/test.json
+++ b/src/content/datasets/test.json
@@ -1,0 +1,21 @@
+{
+  "id": "test",
+  "title": "Testing for Melissa",
+  "status": "published",
+  "description": "This is to show Melissa how to make a dataset. ",
+  "category": "enriched",
+  "temporalCoverageStart": "2009-01-01",
+  "temporalCoverageEnd": "2020-01-31",
+  "spatialCoverage": "Georgia, USA",
+  "updateFrequency": "static",
+  "dataSize": "20GB",
+  "accessPoints": [
+    {
+      "label": "Download",
+      "url": "https://someurl.com/somefile.json",
+      "format": "JSON",
+      "type": "download",
+      "description": "This is the coolest data we got!!!!"
+    }
+  ]
+}

--- a/src/content/datasets/wehe.json
+++ b/src/content/datasets/wehe.json
@@ -1,0 +1,38 @@
+{
+  "id": "wehe",
+  "title": "Wehe Dataset",
+  "status": "published",
+  "description": "The Wehe dataset contains measurements collected by the Wehe app, which detects traffic differentiation (throttling) by ISPs for specific application types such as video streaming, music streaming, and conferencing. Each test replays recorded traffic from popular applications and compares the throughput achieved using original versus anonymized traffic.",
+  "category": "raw",
+  "testRef": "wehe",
+  "temporalCoverageStart": "2018-01-01",
+  "temporalCoverageEnd": "present",
+  "spatialCoverage": "Global",
+  "updateFrequency": "continuous",
+  "accessPoints": [
+    {
+      "label": "BigQuery",
+      "url": "https://console.cloud.google.com/bigquery?project=measurement-lab&p=measurement-lab&d=wehe&page=dataset",
+      "format": "BigQuery",
+      "type": "query",
+      "description": "Parsed Wehe results in BigQuery"
+    },
+    {
+      "label": "Google Cloud Storage (raw)",
+      "url": "gs://archive.measurementlab.net/wehe/",
+      "format": "JSON",
+      "type": "download",
+      "description": "Raw Wehe measurement archives"
+    }
+  ],
+  "documentationLinks": [
+    {
+      "label": "Wehe Test Documentation",
+      "url": "https://www.measurementlab.net/tests/wehe/"
+    },
+    {
+      "label": "Wehe Project (Northeastern University)",
+      "url": "https://wehe.meddle.mobi/"
+    }
+  ]
+}

--- a/src/pages/datasets/[slug].astro
+++ b/src/pages/datasets/[slug].astro
@@ -1,0 +1,315 @@
+---
+/**
+ * /datasets/[slug] — Individual dataset page
+ *
+ * Layout: thin hero → two-column body (main + sidebar)
+ *   Main:    description, access resources, documentation, related datasets
+ *   Sidebar: compact metadata (publisher, license, coverage, etc.), keywords
+ *
+ * Head embeds:
+ *   - schema.org/Dataset JSON-LD
+ *   - Dublin Core <meta> tags
+ *
+ * M-Lab constants (creator, publisher, license, language, type, subject)
+ * are pre-populated here — intentionally not stored in content files.
+ */
+import { getCollection } from 'astro:content';
+import Tag from '@components/atoms/Tag';
+import HeroSection from '@components/sections/HeroSection.astro';
+import PageLayout from '@layouts/PageLayout.astro';
+import SectionLayout from '@layouts/SectionLayout.astro';
+import { isVisible } from '@utils/content';
+import { siteConfig } from '@lib/config';
+
+const MLAB_CREATOR = {
+  '@type': 'Organization' as const,
+  name: 'Measurement Lab',
+  url: siteConfig.url,
+  sameAs: ['https://www.wikidata.org/wiki/Q64928862', 'https://github.com/m-lab'],
+};
+
+const DC_SUBJECT = ['Internet measurement', 'Network performance', 'Broadband', 'Open data'];
+const LICENSE_URL = 'https://creativecommons.org/publicdomain/zero/1.0/';
+
+export async function getStaticPaths() {
+  const datasets = await getCollection('datasets');
+  return datasets
+    .filter((ds) => isVisible(ds))
+    .map((ds) => ({ params: { slug: ds.id }, props: { ds } }));
+}
+
+const { ds } = Astro.props;
+const {
+  title,
+  description,
+  category,
+  temporalCoverageStart,
+  temporalCoverageEnd,
+  spatialCoverage,
+  updateFrequency,
+  accessPoints,
+  dataSize,
+  documentationLinks,
+  testRef,
+  relatedDatasets,
+} = ds.data;
+
+const canonicalUrl = `${siteConfig.url}/datasets/${ds.id}/`;
+
+const temporalCoverage = temporalCoverageStart
+  ? `${temporalCoverageStart}/${temporalCoverageEnd === 'present' || !temporalCoverageEnd ? '..' : temporalCoverageEnd}`
+  : undefined;
+
+const coverageLabel = temporalCoverageStart
+  ? `${temporalCoverageStart.slice(0, 4)}${temporalCoverageEnd ? ` – ${temporalCoverageEnd === 'present' ? 'present' : temporalCoverageEnd.slice(0, 4)}` : ''}`
+  : null;
+
+const distributions = (accessPoints ?? []).map((ap) => ({
+  '@type': 'DataDownload',
+  name: ap.label,
+  description: ap.description,
+  encodingFormat: ap.format,
+  contentUrl: ap.url.startsWith('gs://')
+    ? `https://console.cloud.google.com/storage/browser/${ap.url.replace('gs://', '')}`
+    : ap.url,
+}));
+
+const datasetJsonLd = {
+  '@context': 'https://schema.org/',
+  '@type': 'Dataset',
+  '@id': canonicalUrl,
+  name: title,
+  description,
+  url: canonicalUrl,
+  identifier: canonicalUrl,
+  creator: MLAB_CREATOR,
+  publisher: MLAB_CREATOR,
+  maintainer: MLAB_CREATOR,
+  inLanguage: 'en',
+  license: LICENSE_URL,
+  isAccessibleForFree: true,
+  keywords: DC_SUBJECT,
+  ...(spatialCoverage ? { spatialCoverage: { '@type': 'Place', name: spatialCoverage } } : {}),
+  ...(temporalCoverage ? { temporalCoverage } : {}),
+  ...(distributions.length > 0 ? { distribution: distributions } : {}),
+  ...(testRef ? { isBasedOn: `${siteConfig.url}/tests/${testRef}/` } : {}),
+};
+
+const allDatasets = await getCollection('datasets');
+const related = (relatedDatasets ?? [])
+  .map((id) => allDatasets.find((d) => d.id === id))
+  .filter(Boolean);
+
+const accessUrl = (url: string) =>
+  url.startsWith('gs://')
+    ? `https://console.cloud.google.com/storage/browser/${url.replace('gs://', '')}`
+    : url;
+
+// Format badge colors
+const formatBadge: Record<string, string> = {
+  portal:     'bg-gray-100 text-blue-700',
+  bigquery:   'bg-gray-100 text-amber-700',
+  gcs:        'bg-gray-100 text-green-700',
+  github:     'bg-gray-100 text-gray-600',
+  json:       'bg-gray-100 text-teal-700',
+  parquet:    'bg-gray-100 text-teal-700',
+  csv:        'bg-gray-100 text-teal-700',
+  interactive:'bg-gray-100 text-violet-700',
+};
+
+const getBadgeClass = (format: string) =>
+  formatBadge[format.toLowerCase()] ?? 'bg-gray-100 text-gray-700';
+
+const formatFrequency = (f: string) => f.charAt(0).toUpperCase() + f.slice(1);
+---
+
+<PageLayout
+  title={`${title} — M-Lab Data Catalog`}
+  description={description.slice(0, 160)}
+>
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={JSON.stringify(datasetJsonLd, null, 2)} />
+    <meta name="DC.title" content={title} />
+    <meta name="DC.description" content={description.slice(0, 500)} />
+    <meta name="DC.creator" content="Measurement Lab" />
+    <meta name="DC.publisher" content="Measurement Lab" />
+    <meta name="DC.language" content="en" />
+    <meta name="DC.type" content="Dataset" />
+    <meta name="DC.rights" content="CC0 1.0 Universal (Public Domain)" />
+    <meta name="DC.license" content={LICENSE_URL} />
+    {DC_SUBJECT.map((s) => <meta name="DC.subject" content={s} />)}
+    {temporalCoverage && <meta name="DC.coverage" content={temporalCoverage} />}
+    {spatialCoverage && <meta name="DC.spatial" content={spatialCoverage} />}
+    <meta name="DC.identifier" content={canonicalUrl} />
+    <link rel="canonical" href={canonicalUrl} />
+  </Fragment>
+
+  {/* Hero — title + breadcrumb */}
+  <SectionLayout sectionLabel="hero" zigzag="primary-light" maxWidth="2xl">
+    <HeroSection
+      title={title}
+      subtitle={category === 'enriched' ? 'Enriched Dataset' : category === 'raw' ? 'Raw Dataset' : 'Dataset'}
+    />
+  </SectionLayout>
+
+  {/* Body — two-column layout */}
+  <SectionLayout bgColor="primary-light">
+    <div class="mx-auto max-w-6xl px-4 py-12">
+      <div class="flex flex-col gap-10 lg:flex-row lg:gap-12">
+
+        {/* ── MAIN COLUMN ── */}
+        <div class="min-w-0 flex-1">
+
+          {/* Description */}
+          <section class="mb-10">
+            <h2 class="mb-3 text-xs font-semibold uppercase tracking-widest text-gray-500">About this dataset</h2>
+            <p class="text-base text-gray-800 leading-relaxed">{description}</p>
+          </section>
+
+          {/* Access Resources */}
+          {accessPoints && accessPoints.length > 0 && (
+            <section class="mb-10">
+              <h2 class="mb-4 text-xs font-semibold uppercase tracking-widest text-gray-500">Access the Data</h2>
+              <ul class="divide-y divide-gray-200 rounded-xl border border-gray-200 bg-white overflow-hidden">
+                {accessPoints.map((ap) => (
+                  <li>
+                    <a
+                      href={accessUrl(ap.url)}
+                      target={ap.url.startsWith('http') ? '_blank' : undefined}
+                      rel={ap.url.startsWith('http') ? 'noopener noreferrer' : undefined}
+                      class="block py-4 pr-5 hover:bg-gray-50 transition-colors group"
+                    >
+                      <div class="pl-3 mb-1.5">
+                        <span class={`inline-block rounded-md px-2.5 py-0.5 text-base font-semibold ${getBadgeClass(ap.format)}`}>
+                          {ap.format}
+                        </span>
+                      </div>
+                      <div class="flex items-center justify-between gap-3 pl-5">
+                        <div class="min-w-0">
+                          <div class="text-base font-medium text-gray-900 group-hover:text-blue-700">{ap.label}</div>
+                          {ap.description && (
+                            <div class="text-base text-gray-500 mt-0.5">{ap.description}</div>
+                          )}
+                          {ap.url.startsWith('gs://') && (
+                            <code class="text-xs text-gray-400 font-mono mt-1 block">{ap.url}</code>
+                          )}
+                        </div>
+                        <svg class="h-4 w-4 shrink-0 text-gray-300 group-hover:text-blue-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                        </svg>
+                      </div>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {/* Documentation */}
+          {(documentationLinks ?? []).length > 0 && (
+            <section class="mb-10">
+              <h2 class="mb-4 text-xs font-semibold uppercase tracking-widest text-gray-500">Documentation</h2>
+              <ul class="space-y-2">
+                {documentationLinks!.map((link) => (
+                  <li class="flex items-center gap-2">
+                    <svg class="h-4 w-4 shrink-0 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                    </svg>
+                    <a
+                      href={link.url}
+                      target={link.url.startsWith('http') ? '_blank' : undefined}
+                      rel={link.url.startsWith('http') ? 'noopener noreferrer' : undefined}
+                      class="text-base text-blue-600 hover:underline"
+                    >
+                      {link.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {/* Related Datasets */}
+          {related.length > 0 && (
+            <section>
+              <h2 class="mb-4 text-xs font-semibold uppercase tracking-widest text-gray-500">Related Datasets</h2>
+              <ul class="space-y-2">
+                {related.map((rel) =>
+                  rel ? (
+                    <li class="flex items-center gap-2">
+                      <svg class="h-4 w-4 shrink-0 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                      </svg>
+                      <a href={`/datasets/${rel.id}`} class="text-base text-blue-600 hover:underline">
+                        {rel.data.title}
+                      </a>
+                    </li>
+                  ) : null
+                )}
+              </ul>
+            </section>
+          )}
+        </div>
+
+        {/* ── SIDEBAR ── */}
+        <aside class="lg:w-72 shrink-0">
+          <div class="rounded-xl border border-gray-200 bg-white overflow-hidden">
+            <div class="px-5 py-4 border-b border-gray-100 bg-gray-50">
+              <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500">Dataset Info</h2>
+            </div>
+            <dl class="divide-y divide-gray-100">
+              <div class="px-5 py-3">
+                <dt class="text-xs text-gray-400 mb-0.5">Publisher</dt>
+                <dd class="text-sm font-medium text-gray-900">
+                  <a href={siteConfig.url} class="hover:underline">Measurement Lab</a>
+                </dd>
+              </div>
+              <div class="px-5 py-3">
+                <dt class="text-xs text-gray-400 mb-0.5">License</dt>
+                <dd class="text-sm font-medium">
+                  <a href={LICENSE_URL} target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">
+                    CC0 1.0 Universal
+                  </a>
+                </dd>
+              </div>
+              {coverageLabel && (
+                <div class="px-5 py-3">
+                  <dt class="text-xs text-gray-400 mb-0.5">Coverage</dt>
+                  <dd class="text-sm font-medium text-gray-900">{coverageLabel}</dd>
+                </div>
+              )}
+              {updateFrequency && (
+                <div class="px-5 py-3">
+                  <dt class="text-xs text-gray-400 mb-0.5">Updated</dt>
+                  <dd class="text-sm font-medium text-gray-900">{formatFrequency(updateFrequency)}</dd>
+                </div>
+              )}
+              {spatialCoverage && (
+                <div class="px-5 py-3">
+                  <dt class="text-xs text-gray-400 mb-0.5">Geography</dt>
+                  <dd class="text-sm font-medium text-gray-900">{spatialCoverage}</dd>
+                </div>
+              )}
+              {dataSize && (
+                <div class="px-5 py-3">
+                  <dt class="text-xs text-gray-400 mb-0.5">Approximate size</dt>
+                  <dd class="text-sm font-medium text-gray-900">{dataSize}</dd>
+                </div>
+              )}
+              {testRef && (
+                <div class="px-5 py-3">
+                  <dt class="text-xs text-gray-400 mb-0.5">Source test</dt>
+                  <dd class="text-sm font-medium">
+                    <a href={`/tests/${testRef}/`} class="text-blue-600 hover:underline">{testRef}</a>
+                  </dd>
+                </div>
+              )}
+            </dl>
+          </div>
+
+        </aside>
+
+      </div>
+    </div>
+  </SectionLayout>
+</PageLayout>

--- a/src/pages/datasets/index.astro
+++ b/src/pages/datasets/index.astro
@@ -1,0 +1,79 @@
+---
+/**
+ * /datasets — M-Lab Data Catalog
+ *
+ * Follows the same pattern as [..path].astro / TestsLanding:
+ *   1. Thin hero (title + subtitle) — maxWidth="2xl", zigzag
+ *   2. Intro paragraph in a section below
+ *   3. DatasetsLanding — handles its own SectionLayouts per category group
+ *
+ * Embeds schema.org DataCatalog JSON-LD in <head>.
+ */
+import { getCollection } from 'astro:content';
+import DatasetsLanding from '@components/landing/DatasetsLanding.astro';
+import HeroSection from '@components/sections/HeroSection.astro';
+import PageLayout from '@layouts/PageLayout.astro';
+import SectionLayout from '@layouts/SectionLayout.astro';
+import { isVisible } from '@utils/content';
+import { siteConfig } from '@lib/config';
+
+const allDatasets = await getCollection('datasets');
+const publishedDatasets = allDatasets.filter((ds) => isVisible(ds));
+
+const catalogJsonLd = {
+  '@context': 'https://schema.org/',
+  '@type': 'DataCatalog',
+  name: 'Measurement Lab Open Data Catalog',
+  description: 'Open Internet measurement datasets collected by Measurement Lab, released under CC0 1.0 Universal.',
+  url: `${siteConfig.url}/datasets/`,
+  publisher: { '@type': 'Organization', name: 'Measurement Lab', url: siteConfig.url },
+  license: 'https://creativecommons.org/publicdomain/zero/1.0/',
+  keywords: ['Internet measurement', 'Network performance', 'Broadband', 'Open data'],
+  dataset: publishedDatasets.map((ds) => ({
+    '@type': 'Dataset',
+    name: ds.data.title,
+    description: ds.data.description,
+    url: `${siteConfig.url}/datasets/${ds.id}/`,
+    license: 'https://creativecommons.org/publicdomain/zero/1.0/',
+    creator: { '@type': 'Organization', name: 'Measurement Lab' },
+    spatialCoverage: ds.data.spatialCoverage ?? 'Global',
+    ...(ds.data.temporalCoverageStart
+      ? { temporalCoverage: `${ds.data.temporalCoverageStart}/${ds.data.temporalCoverageEnd === 'present' ? '..' : (ds.data.temporalCoverageEnd ?? '..')}` }
+      : {}),
+    keywords: ['Internet measurement', 'Network performance', 'Broadband', 'Open data'],
+  })),
+};
+---
+
+<PageLayout
+  title="Data Catalog"
+  description="Open Internet measurement datasets from Measurement Lab, released under CC0."
+>
+  <script slot="head" type="application/ld+json" set:html={JSON.stringify(catalogJsonLd, null, 2)} />
+
+  {/* Hero — thin, matches [..path].astro */}
+  <SectionLayout sectionLabel="hero" zigzag="primary-light" maxWidth="2xl">
+    <HeroSection
+      title="Data Catalog"
+      subtitle="Open Internet measurement data released under CC0 — freely available for research, policy, and public interest analysis."
+    />
+  </SectionLayout>
+
+  {/* Intro — pushed below hero as a separate section */}
+  <SectionLayout bgColor="primary-light">
+    <div class="mx-auto max-w-4xl py-10 px-4">
+      <p class="text-gray-700 text-base leading-relaxed">
+        M-Lab data is published in two forms: <strong>enriched data</strong> (parsed,
+        annotated, and queryable via BigQuery or available as pre-computed summaries) and <strong>archival data</strong> (measurement
+        logs on Google Cloud Storage for deeper analysis). Both are released under{' '}
+        <a href="https://creativecommons.org/publicdomain/zero/1.0/" target="_blank" rel="noopener noreferrer" class="underline">
+          CC0 1.0 Universal
+        </a>{' '}
+        with no restrictions on use.
+      </p>
+    </div>
+  </SectionLayout>
+
+  {/* Dataset listing — DatasetsLanding manages its own SectionLayouts */}
+  <DatasetsLanding />
+</PageLayout>


### PR DESCRIPTION
feat: add datasets data catalog

- Add datasets Astro content collection (Dublin Core schema)
- Add DatasetsLanding.astro with client-side search/filter
- Add /datasets/ catalog index with DataCatalog JSON-LD
- Add /datasets/[slug] detail pages with Dataset JSON-LD, Dublin Core meta
- Add datasets to Pages CMS (.pages.yml), user-editable fields only
- Add two sample datasets: NDT and Wehe

